### PR TITLE
Clear filters prior to returning edited rows.

### DIFF
--- a/src/js/simpleGrid.js
+++ b/src/js/simpleGrid.js
@@ -619,7 +619,11 @@
             else if (options.markRowEdited) {
                 editSelector = $tbl.find('tbody tr.' + options.editedClass).not('.' + options.deletedClass);
             }
-
+            
+            $tbl.search( '' )
+                .columns().search( '' )
+                .draw();
+                
             var editOnly = getEditedCollection($tbl, editSelector, false, options, wrapperObject, editors),
                 deleteOnly = getEditedCollection($tbl, deleteSelector, true, options, wrapperObject, editors);
 


### PR DESCRIPTION
If the datatable is filtered, the function to return the edited collection returns incorrect results.  Clearing the filters prior to accessing these rows should not present much of a problem to the UI, as the only time these edited rows will be returned (well - in normal usage) will be when the data is going to be saved.  Thus, clearing the filters won't hurt, and will fix the problem of data being missed when sending to a POST or what have you.
