### PR TITLE
Revert "Clear filters prior to returning edited rows."

### DIFF
--- a/src/js/simpleGrid.js
+++ b/src/js/simpleGrid.js
@@ -619,11 +619,7 @@
             else if (options.markRowEdited) {
                 editSelector = $tbl.find('tbody tr.' + options.editedClass).not('.' + options.deletedClass);
             }
-            
-            $tbl.search( '' )
-                .columns().search( '' )
-                .draw();
-                
+
             var editOnly = getEditedCollection($tbl, editSelector, false, options, wrapperObject, editors),
                 deleteOnly = getEditedCollection($tbl, deleteSelector, true, options, wrapperObject, editors);
 


### PR DESCRIPTION
Reverts processedbeets/simple-grid#2

OK, this may still be all right to leave in, as it works ... but it's not necessary.  The problem I was trying to solve turned out not to be in the library, but in the form itself - I wasn't Ajax-submitting the data, but was submitting the form with inputs which were hidden by the DataTable, which doesn't work apparently.
