### PR TITLE
pdfHtml5 button causes exception.

### DIFF
--- a/src/js/simpleGrid.js
+++ b/src/js/simpleGrid.js
@@ -781,7 +781,7 @@
                                 var select = $('<select class="form-control"><option value=""></option></select>')
                                     .appendTo($(column.footer()).empty())
                                     .on('change', function () {
-                                        column.search($(this).val());
+                                        column.search($(this).val(), false, false);
                                         if (dataTableOptions.definition.serverSide) {
                                             dataTable.ajax.reload();
                                         } else {
@@ -800,8 +800,7 @@
                                 $('<input class="form-control table-filters" type="text" />')
                                     .appendTo($(column.footer()).empty())
                                     .on('keyup change', function () {
-                                        column.search($(this).val(), false);
-
+                                        column.search($(this).val(), false, false);
                                         if (dataTableOptions.definition.serverSide) {
                                             dataTable.ajax.reload();
                                         } else {

--- a/src/js/simpleGrid.js
+++ b/src/js/simpleGrid.js
@@ -737,7 +737,7 @@
                 orderClasses: false,
                 pagingType: "full_numbers",
                 buttons: [
-                    'colvis', 'copy', 'csv', 'excel', { extend: 'pdfHtml5', orientation: 'landscape' }
+                    'colvis', 'copy', 'csv', 'excel'
                 ],
                 "columnDefs": [
                     {


### PR DESCRIPTION
Not sure if I could have just plugged in the button by name rather than removing the extension altogether, but....

Line 740, removed:

, { extend: 'pdfHtml5', orientation: 'landscape' }

Uncaught Cannot extend unknown button type: pdfHtml5

I suspect this is an underlying change to DataTables.